### PR TITLE
fix: PerpIntercept calculation errarray fix

### DIFF
--- a/GeoFormulas/PerpIntercept.cpp
+++ b/GeoFormulas/PerpIntercept.cpp
@@ -78,7 +78,7 @@ namespace GeoCalcs {
         double dist23 = result.distance;
 
         double errarray[2], distarray[2];
-        errarray[0] = fabs(SignAzimuthDifference(crs31, crs32)) - M_PI;
+        errarray[0] = fabs(SignAzimuthDifference(crs31, crs32)) - M_PI_2;
         distarray[0] = dist13;
         distarray[1] = fabs(distarray[0] + errarray[0] * dist23);
 


### PR DESCRIPTION
This fixes Perpendicular Intercept calculation which didn't work in this case:

`
Pt1 = lat: 69.75, lon: 24.6666666667
Crs13 = 0
Pt2 = lat: 58.017290777777774, lon: 7.500205888888889
`

There is a new FAA document that fixes the original:
https://www.faa.gov/documentLibrary/media/Order/FAA_Order_8260.58A_Including_Change_1_and_2.pdf

(Please note there are some other changes in the algorithm, though I'm not sure how significant. They don't seem to affect the case described above.)
